### PR TITLE
Adding Wayland support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Hidamari offers similar feature as above, with additional features listed below:
 - [x] Volume level
 - [x] Pause the video playback manually at anytime
 - [x] I'm feeling lucky. Randomly select and play the video
+- [x] GPU decoding (thanks 94824!) 
 - [ ] You name it! =)
 
 ## Installation (Fedora)
@@ -26,7 +27,7 @@ Hidamari offers similar feature as above, with additional features listed below:
 ## Installation (Other linux)
 ### Prerequisite
 1. PyGObject, refer to [Installation](https://pygobject.readthedocs.io/en/latest/getting_started.html)
-2. Pillow, pydbus, Watchdog `pip3 install pillow pydbus watchdog`
+2. Pillow, pydbus, Watchdog `pip3 install pillow pydbus watchdog python-vlc`
 3. Multimedia codecs, refer to [Ubuntu](https://itsfoss.com/install-media-codecs-ubuntu/)
 4. FFmpeg
 

--- a/src/hidamari
+++ b/src/hidamari
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 import argparse
 import time
+import os
+
+# Make sure that X11 is the backend. This makes sure Wayland reverts to XWayland.
+os.environ['GDK_BACKEND'] = "x11"
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/src/player.py
+++ b/src/player.py
@@ -16,35 +16,28 @@ from gui import ControlPanel, create_dir, scan_dir
 VIDEO_WALLPAPER_PATH = os.environ['HOME'] + '/Videos/Hidamari'
 
 
-def get_window_pointer(window):
-    """ Use the window.__gpointer__ PyCapsule to get the C void* pointer to the window
-    """
-    # get the c gpointer of the gdk window
-    ctypes.pythonapi.PyCapsule_GetPointer.restype = ctypes.c_void_p
-    ctypes.pythonapi.PyCapsule_GetPointer.argtypes = [ctypes.py_object]
-    return ctypes.pythonapi.PyCapsule_GetPointer(window.__gpointer__, None)
-
-
 class VLCWidget(Gtk.DrawingArea):
-    """Simple VLC widget.
+    """
+    Simple VLC widget.
     Its player can be controlled through the 'player' attribute, which
     is a vlc.MediaPlayer() instance.
     """
     __gtype_name__ = 'VLCWidget'
 
     def __init__(self, width, height):
+
+        # Spawn a VLC instance and create a new media player to embed.
         self.instance = vlc.Instance()
         Gtk.DrawingArea.__init__(self)
         self.player = self.instance.media_player_new()
-        self.width = width
-        self.height = height
 
         def handle_embed(*args):
             self.player.set_xwindow(self.get_window().get_xid())
             return True
 
+        # Embed and set size.
         self.connect("realize", handle_embed)
-        self.set_size_request(self.width, self.height)
+        self.set_size_request(width, height)
 
 
 class Player:
@@ -66,13 +59,25 @@ class Player:
         # Monitor Detect
         self.width, self.height = self.monitor_detect()
 
+        # We need to initialize X11 threads so we can use hardware decoding.
         x11 = ctypes.cdll.LoadLibrary('libX11.so')
         x11.XInitThreads()
 
+        # Setup a VLC widget given the provided width and height.
         self.video_playback = VLCWidget(self.width, self.height)
         self.media = self.video_playback.instance.media_new(self.config.video_path)
+
+        """
+        This loops the media itself. Using -R / --repeat and/or -L / --loop don't seem to work. However,
+        based on reading, this probably only repeats 65535 times, which is still a lot of time, but might
+        cause the program to stop playback if it's left on for a very long time.
+        """
         self.media.add_option("input-repeat=65535")
+
         self.video_playback.player.set_media(self.media)
+
+        # These are to allow us to right click. VLC can't hijack mouse input, and probably not key inputs either in
+        # Case we want to add keyboard shortcuts later on.
         self.video_playback.player.video_set_mouse_input(False)
         self.video_playback.player.video_set_key_input(False)
 
@@ -103,6 +108,7 @@ class Player:
         self.current = 0
         if self.config.video_path in self.file_list:
             self.current = self.file_list.index(self.config.video_path)
+
         Gtk.main()
 
     def pause_playback(self):


### PR DESCRIPTION
Hello again!

I was tinkering around, especially with the new gestures on Gnome 40--and really wanted this project to work on wayland. I wasn't able to figure how to do it natively, but it works very well under XWayland.

The problem was that self.screen.get_active_workspace() in Wnck didn't play nice, so I just used xprop. I believe that xprop should be available on any xorg setup, so I don't think a new dependency is required. 

Also, I'm not entirely sure if this setup works under hibernation, because I don't have it setup on my system--so it might break under that. 

Other than that, I just added some documentation to the existing VLC stuff, it was kinda bare and there was some stuff that didn't need to be there.