### PR TITLE
Zoom wide video into the thin screen(16x9 to 16x10) to fill it entirely

### DIFF
--- a/src/player/video_player.py
+++ b/src/player/video_player.py
@@ -186,7 +186,7 @@ class PlayerWindow(Gtk.ApplicationWindow):
 
         else:
             # If video is wider than window
-            crop_width = video_width * window_ratio
+            crop_width = video_height * window_ratio
             left_offset = (video_width - crop_width) / 2
             crop_geometry = f"{int(crop_width+left_offset)}x{int(video_height)}+{int(left_offset)}+0"
 


### PR DESCRIPTION
I have a 16x10 monitor(1920x1200), but most of the live wallpaper videos on youtube are with 16x9 aspect ratio. Current logic puts the video in the center of the screen with top and bottom black bars. I think it's better to zoom video and crop it so it fills the entire screen.

<details>
<summary>Before</summary>

![image](https://user-images.githubusercontent.com/18462555/198717158-3cbc2351-fa2e-4b18-bcdd-60004dc0c8e6.png)

</details>

<details>
<summary>After</summary>

![image](https://user-images.githubusercontent.com/18462555/198717237-18e6267a-5b02-4b58-9f80-ef575326a6c1.png)

</details>