### PR TITLE
Update Gnome runtime to version 48

### DIFF
--- a/io.github.jeffshee.Hidamari.json
+++ b/io.github.jeffshee.Hidamari.json
@@ -1,7 +1,7 @@
 {
     "app-id": "io.github.jeffshee.Hidamari",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "47",
+    "runtime-version": "48",
     "sdk": "org.gnome.Sdk",
     "command": "hidamari",
     "finish-args": [
@@ -49,8 +49,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/gnome-desktop.git",
-                    "commit": "97c0344b3ba955bb6f6fe74ca03cc399a81acaa5",
-                    "tag": "44.0"
+                    "commit": "33516379260c09db7435432c7a250ce64afaad6e",
+                    "tag": "44.4"
                 }
             ]
         },
@@ -76,7 +76,7 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/GNOME/totem-video-thumbnailer.git",
-                    "commit": "78ddf6c113d439d8ad9ff1453cf433592fabe9fd"
+                    "commit": "6cb399918571a97591ff5a4a5a41d8e46b11027a"
                 }
             ]
         },
@@ -91,21 +91,18 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/libwnck/43/libwnck-43.0.tar.xz",
-                    "sha256": "905bcdb85847d6b8f8861e56b30cd6dc61eae67ecef4cd994a9f925a26a2c1fe"
+                    "url": "https://download.gnome.org/sources/libwnck/43/libwnck-43.3.tar.xz",
+                    "sha256": "6af8ac41a8f067ade1d3caaed254a83423b5f61ad3f7a460fcacbac2e192bdf7"
                 }
             ]
         },
         {
             "name": "mesa-demos",
+            "buildsystem":"autotools",
             "config-opts": [
                 "--without-glut",
-                "--bindir=/app/lib/mesa-demos"
-            ],
-            "make-args": [
-                "-C",
-                "src/xdemos",
-                "glxinfo"
+                "--bindir=/app/lib/mesa-demos",
+                "--enable-autotools"
             ],
             "no-make-install": true,
             "build-commands": [
@@ -114,8 +111,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://mesa.freedesktop.org/archive/demos/mesa-demos-8.4.0.tar.bz2",
-                    "sha256": "01e99c94a0184e63e796728af89bfac559795fb2a0d6f506fa900455ca5fff7d"
+                    "url": "https://archive.mesa3d.org/demos/8.5.0/mesa-demos-8.5.0.tar.bz2",
+                    "sha256": "cea2df0a80f09a30f635c4eb1a672bf90c5ddee0b8e77f4d70041668ef71aac1"
                 }
             ],
             "cleanup": [
@@ -144,8 +141,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/flatpak/libportal/releases/download/0.8.1/libportal-0.8.1.tar.xz",
-                    "sha256": "281e54e4f8561125a65d20658f1462ab932b2b1258c376fed2137718441825ac",
+                    "url": "https://github.com/flatpak/libportal/releases/download/0.9.1/libportal-0.9.1.tar.xz",
+                    "sha256": "de801ee349ed3c255a9af3c01b1a401fab5b3fc1c35eb2fd7dfb35d4b8194d7f",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/flatpak/libportal/releases/latest",
@@ -166,8 +163,5 @@
                 }
             ]
         }
-    ],
-    "build-options": {
-        "env": {}
-    }
+    ]
 }

--- a/libvlc/cmake-min-version.patch
+++ b/libvlc/cmake-min-version.patch
@@ -1,0 +1,5 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1 +1 @@
+-cmake_minimum_required(VERSION 3.1.2)
++cmake_minimum_required(VERSION 3.5)

--- a/libvlc/x265-cmake.patch
+++ b/libvlc/x265-cmake.patch
@@ -1,0 +1,20 @@
+--- a/source/CMakeLists.txt
++++ b/source/CMakeLists.txt
+@@ -8,13 +8,13 @@
+ message(STATUS "cmake version ${CMAKE_VERSION}")
+ if(POLICY CMP0025)
+-    cmake_policy(SET CMP0025 OLD) # report Apple's Clang as just Clang
++    cmake_policy(SET CMP0025 NEW) # modern behavior required for CMake >= 4.0
+ endif()
+ if(POLICY CMP0042)
+     cmake_policy(SET CMP0042 NEW) # MACOSX_RPATH
+ endif()
+ if(POLICY CMP0054)
+-    cmake_policy(SET CMP0054 OLD) # Only interpret if() arguments as variables or keywords when unquoted
++    cmake_policy(SET CMP0054 NEW) # Required since OLD behavior removed
+ endif()
+
+-project (x265)
+-cmake_minimum_required (VERSION 2.8.8) # OBJECT libraries require 2.8.8
++cmake_minimum_required (VERSION 3.5)
++project (x265)

--- a/vlc-slim.json
+++ b/vlc-slim.json
@@ -13,7 +13,7 @@
         "*.la",
         "*.a"
     ],
-    "cleanup-commands": [
+    "post-install": [
         "mkdir -p /app/share/vlc/extra",
         "ln -s /app/share/vlc/extra/plugins /app/lib/vlc/plugins/extra",
         "rm -f /app/lib/vlc/plugins/plugins.dat",
@@ -77,6 +77,10 @@
                     "type": "archive",
                     "url": "https://dl.matroska.org/downloads/libebml/libebml-1.4.5.tar.xz",
                     "sha256": "4971640b0592da29c2d426f303e137a9b0b3d07e1b81d069c1e56a2f49ab221b"
+                },
+                {
+                "type": "patch",
+                "path": "libvlc/cmake-min-version.patch"
                 }
             ]
         },
@@ -94,6 +98,10 @@
                     "type": "archive",
                     "url": "https://dl.matroska.org/downloads/libmatroska/libmatroska-1.7.1.tar.xz",
                     "sha256": "572a3033b8d93d48a6a858e514abce4b2f7a946fe1f02cbfeca39bfd703018b3"
+                },
+                {
+                "type": "patch",
+                "path": "libvlc/cmake-min-version.patch"
                 }
             ]
         },
@@ -125,7 +133,7 @@
                 {
                     "type": "git",
                     "url": "https://code.videolan.org/videolan/x264.git",
-                    "commit": "a8b68ebfaa68621b5ac8907610d3335971839d52"
+                    "commit": "0480cb05fa188d37ae87e8f4fd8f1aea3711f7ee"
                 }
             ]
         },
@@ -142,8 +150,12 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://bitbucket.org/multicoreware/x265_git/downloads/x265_3.6.tar.gz",
-                    "sha256": "663531f341c5389f460d730e62e10a4fcca3428ca2ca109693867bc5fe2e2807"
+                    "url": "https://bitbucket.org/multicoreware/x265_git/downloads/x265_4.1.tar.gz",
+                    "sha256": "a31699c6a89806b74b0151e5e6a7df65de4b49050482fe5ebf8a4379d7af8f29"
+                },
+                {
+                    "type": "patch",
+                    "path": "libvlc/x265-cmake.patch"
                 }
             ]
         },
@@ -153,8 +165,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.videolan.org/videolan/dav1d/1.4.2/dav1d-1.4.2.tar.xz",
-                    "sha256": "7392cf4c432734eebb383319b5e05e994bffdcdfe66f82287c38873601a4ef0b"
+                    "url": "https://download.videolan.org/videolan/dav1d/1.5.2/dav1d-1.5.2.tar.xz",
+                    "sha256": "cce88ebcffd3f790bde49caa75f97b9cc2dd54ca8f57e38c62707266ec71bc4e"
                 }
             ]
         },
@@ -227,9 +239,9 @@
             ],
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://github.com/Haivision/srt/archive/v1.5.3.tar.gz",
-                    "sha256": "befaeb16f628c46387b898df02bc6fba84868e86a6f6d8294755375b9932d777"
+                    "type": "git",
+                    "url": "https://github.com/Haivision/srt.git",
+                    "commit": "c09532f8edf28de91854f975bb16e643e8085ed9"
                 }
             ]
         },
@@ -278,6 +290,8 @@
             "name": "vlc",
             "config-opts": [
                 "BUILDCC=/usr/bin/gcc -std=gnu99",
+                "CFLAGS=-U_FORTIFY_SOURCE",
+                "CXXFLAGS=-U_FORTIFY_SOURCE",
                 "--disable-archive",
                 "--disable-dc1394",
                 "--disable-dv1394",


### PR DESCRIPTION
Just mirrored all changes from https://github.com/flathub/io.github.jeffshee.Hidamari/pull/18 as preparation for new Hidamari version release.